### PR TITLE
The regexp slash was interpreted as escape code

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Following *options* are available for *UploadServer.init(options)*:
 | minFileSize | int | 1 | Minimum file size
 | maxFileSize | int | 10000000000 | Maximum file size (10 GB) 
 | acceptFileTypes | RegEx | /.+/i, | Accepted types of files (e.g. prohibit .exe)
-| imageTypes | RegEx | /\.(gif\|jpe?g\|png)$/i | Images which can be resized with *Imagemagick*
+| imageTypes | RegEx | /\\.(gif\|jpe?g\|png)$/i | Images which can be resized with *Imagemagick*
 | imageVersions | Object | {} | Defines the sizes of images which will be converted and saved to upload directory. For example `{thumbnailBig: {width: 400, height: 300}, thumbnailSmall: {width: 200, height: 100}}` | 
 | getDirectory | function |  | functions which decides the subdirectory in which the file will be saved. If this function is not defined, no sub-directory is created. For example: `function(fileInfo, formData) { return '/my/sub/directory';` }
 | getFileName | function |  | Renames the file on the server. In no function is specified, file is saved with the original file name. For example: `function(fileInfo, formData) { return 'Saved-' + file.name; }`


### PR DESCRIPTION
I think it should be a double slash, so people can copy paste from the readme when rendered as html.
